### PR TITLE
feat: allow querying date of data

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set minor version
         if: steps.verify-changes.outputs.files_changed == 'true'
         run: |
-          NEXT_MINOR=$GITHUB_RUN_NUMBER
+          NEXT_MINOR=$(date -u +%Y%m%d%H%M)
           sed -i "s/MINOR[[:space:]]*=[[:space:]]*[[:digit:]]\+/MINOR = $NEXT_MINOR/" MountsRarity.lua
 
       - name: Define release tag

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -26,11 +26,13 @@ jobs:
           files: |
             MountsRarity.lua
 
-      - name: Set minor version
+      - name: Set minor version and last-updated timestamp
         if: steps.verify-changes.outputs.files_changed == 'true'
         run: |
-          NEXT_MINOR=$(date -u +%Y%m%d%H%M)
+          NOW_EPOCH=$(date -u +%s)
+          NEXT_MINOR=$(date -u -d "@$NOW_EPOCH" +%Y%m%d%H%M)
           sed -i "s/MINOR[[:space:]]*=[[:space:]]*[[:digit:]]\+/MINOR = $NEXT_MINOR/" MountsRarity.lua
+          sed -i "s/LAST_UPDATED[[:space:]]*=[[:space:]]*[[:digit:]]\+/LAST_UPDATED = $NOW_EPOCH/" MountsRarity.lua
 
       - name: Define release tag
         if: steps.verify-changes.outputs.files_changed == 'true'

--- a/MountsRarity.lua
+++ b/MountsRarity.lua
@@ -20,7 +20,8 @@
 
 ----------------------------------------------------------------------------]]--
 
--- This build version gets automatically updated.
+-- This build version gets automatically updated to the current UTC date and time (YYYYMMDDHHMM).
+-- Using a timestamp instead of e.g. a CI run number keeps this reproducible across forks and git hosts.
 local MINOR = 1082
 ---@class MountsRarity: { GetData: function, GetRarityByID: function }
 local MountsRarity = LibStub:NewLibrary("MountsRarity-2.0", MINOR)

--- a/MountsRarity.lua
+++ b/MountsRarity.lua
@@ -21,15 +21,14 @@
 ----------------------------------------------------------------------------]]--
 
 -- This build version gets automatically updated to the current UTC date and time (YYYYMMDDHHMM).
--- Using a timestamp instead of e.g. a CI run number keeps this reproducible across forks and git hosts.
-local MINOR = 1082
+local MINOR = 202608090233
 ---@class MountsRarity: { GetData: function, GetRarityByID: function }
 local MountsRarity = LibStub:NewLibrary("MountsRarity-2.0", MINOR)
 if not MountsRarity then return end -- already loaded and no upgrade necessary
 
 -- The UTC time this data was last generated, as a Unix timestamp (seconds since epoch).
 -- Gets automatically updated alongside MINOR whenever the data changes.
-local LAST_UPDATED = 1786309688
+local LAST_UPDATED = 1786242798
 
 local lazyLoadData = function()
   return {}

--- a/MountsRarity.lua
+++ b/MountsRarity.lua
@@ -27,6 +27,10 @@ local MINOR = 1082
 local MountsRarity = LibStub:NewLibrary("MountsRarity-2.0", MINOR)
 if not MountsRarity then return end -- already loaded and no upgrade necessary
 
+-- The UTC time this data was last generated, as a Unix timestamp (seconds since epoch).
+-- Gets automatically updated alongside MINOR whenever the data changes.
+local LAST_UPDATED = 1786309688
+
 local lazyLoadData = function()
   return {}
 end
@@ -59,6 +63,13 @@ end
 ---@param mountID number The mount ID.
 function MountsRarity:GetRarityByID(mountID)
   return self:GetData()[mountID]
+end
+
+---Returns the UTC time this library's data was last generated, as a Unix timestamp
+---(seconds since epoch). Pass it to `date()` for formatting, or compare it against
+---`time()` to derive a relative age.
+function MountsRarity:GetLastUpdated()
+  return LAST_UPDATED
 end
 
 -- Everything after this line gets automatically replaced and updated.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ To get the entire dataset, organized by mount id and its rarity, call `GetData()
 local data = MountsRarity:GetData()
 ```
 
+### Get the data's age
+
+To find out when the shipped rarity data was last generated, call `GetLastUpdated()`. It returns a Unix timestamp (seconds since epoch, UTC), so you can format it yourself (e.g. with `date()`) or compare it against `time()` to show a relative age.
+
+```lua
+local lastUpdated = MountsRarity:GetLastUpdated()
+print(date("%Y-%m-%d", lastUpdated))
+```
+
 ## 📊 Data source
 
 The data source for the rarity data is [Data for Azeroth](https://www.dataforazeroth.com/collections/mounts).


### PR DESCRIPTION
Adds `GetLastUpdated()` which returns a UNIX epoch. This is the time at which the data was queried.

<img width="586" height="102" alt="Screenshot 2026-08-09 at 23 39 56" src="https://github.com/user-attachments/assets/c3805c4c-93e0-438a-b749-b7cabdd216d1" />

You can use this to show the age of the data to your users or perform other logic with it (e.g., alert them if the installed data add-on version is too old).
As reference, Data for Azeroth usually updates their data twice a week.